### PR TITLE
Add aria-hidden attribute to theme wave

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
   <script src="js/mobile-menu.js"></script>
   <script src="js/scroll-animations.js"></script>
   <div class="theme-transition-overlay">
-    <svg class="theme-wave" viewBox="0 0 1440 800" preserveAspectRatio="none">
+    <svg class="theme-wave" aria-hidden="true" viewBox="0 0 1440 800" preserveAspectRatio="none">
       <path class="wave" d="M0,800 C450,800 950,400 1440,800 L1440,0 C950,0 450,0 0,0 Z"></path>
     </svg>
   </div>


### PR DESCRIPTION
## Summary
- hide decorative wave from screen readers by adding `aria-hidden="true"`

## Testing
- `npm test` *(fails: `Could not read package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684030fc9434832090543efeef7e40f3